### PR TITLE
Set ARG GRADLE_VERSION instead of ENV GRADLE_VERSION.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM java:8-jdk
 MAINTAINER Dave Henderson <dhenderson@gmail.com>
 
-ENV GRADLE_VERSION 2.6
+ARG GRADLE_VERSION=2.6
 
 WORKDIR /usr/bin
 RUN curl -sLO https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-all.zip && \

--- a/README.md
+++ b/README.md
@@ -2,6 +2,21 @@
 
 A Java development image with Gradle installed.
 
+## How to build
+
+The Docker image can be built using the following command
+
+```{bash}
+docker build -t <your Docker Hub ID>/gradle .
+```
+
+where the dot is the current folder, assuming you are running the docker command from the same folder of the Dockerfile.
+If you want a specific Gradle version, build the image with this command instead:
+
+```{bash}
+docker build -t <your Docker Hub ID>/gradle --build-arg GRADLE_VERSION=<Gradle version> .
+```
+
 ## License
 
 This image packages [Gradle](https://github.com/gradle/gradle), which is licensed under the [Apache 2.0](http://www.apache.org/licenses/LICENSE-2.0) license.


### PR DESCRIPTION
In the proposed change, instead of using ENV for defining GRADLE_VERSION, I used ARG, so I can build new versions of the image for new Gradle version without having to change the variable manually in the Dockerfile.